### PR TITLE
Add sqlite database output using sqlx & remove csv output.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ socketcan = "3.3.0"
 embedded-can = "0.4.1"
 nmea = "0.6.0"
 half = "2.3.1"
+anyhow = "1.0.80"
+sqlx = {version = "0.7.3",features = ["sqlite","runtime-tokio"]}
+tokio = { version = "1.36.0", features = ["full"] }
 
 [[bin]]
 name = "rpi4-canbus-server"


### PR DESCRIPTION
Added anyhow so that functions would return multiple error types, which was needed for both io errors for canbus and sqlx errors for sqlx.
Currently the one gps table is created by the main function. In the future this will be moved to the parser when it is created. 
Currently skips fix_type as I cant find a good way to convert that to a string.
Tried to make a separate function but I cant get rust to recognize the enum