### PR TITLE
Update the BCM version and add Test script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
+BCM_VER='1.75'
 # Define the lines to be added
 lines_to_add="dtparam=spi=on
 dtoverlay=mcp2515-can1,oscillator=16000000,interrupt=25
@@ -25,10 +26,9 @@ echo -e "$lines_to_add" | sudo tee -a /boot/config.txt
 echo "Lines added to /boot/config.txt successfully."
 
 #https://www.waveshare.com/wiki/2-CH_CAN_HAT
-
-wget http://www.airspayce.com/mikem/bcm2835/bcm2835-1.60.tar.gz
-tar zxvf bcm2835-1.60.tar.gz 
-cd bcm2835-1.60/
+wget http://www.airspayce.com/mikem/bcm2835/bcm2835-${BCM_VER}.tar.gz
+tar zxvf bcm2835-${BCM_VER}.tar.gz 
+cd bcm2835-${BCM_VER}/
 sudo ./configure
 sudo make
 sudo make check
@@ -36,6 +36,9 @@ sudo make install
 
 
 sudo apt-get install can-utils
+
+# Allows on pi sessions and terminal multiplexing(useful for can testing)
+sudo apt install tmux
 
 echo "Install complete, rebooting to enable spi"
 sleep 5

--- a/test_can.sh
+++ b/test_can.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Author: Jake G
+# Date: 2024
+# Filename: test_cam.sh
+
+#Descripion: 
+#show how can works on the pi by running a test of can1 --> can0
+
+
+SPEED=1000000
+QUEUE_LEN=65536
+
+setup_can () {
+    sudo ip link set can0 up type can bitrate ${SPEED}
+    sudo ip link set can1 up type can bitrate ${SPEED}
+    sudo ifconfig can0 txqueuelen ${QUEUE_LEN}
+    sudo ifconfig can1 txqueuelen ${QUEUE_LEN}
+
+    # Sometimes required
+    sudo ip link set can0 up
+    sudo ip link set can1 up
+}
+
+tear_down_can () {
+    sudo ip link set can0 down
+    sudo ip link set can1 down
+}
+
+print_info () {
+    echo "##########################"
+    echo "CAN TEST v0.0.0"
+    echo "##########################"
+    echo "For: SBC 2ch CAN"
+    echo "SPEED: ${SPEED}"
+    echo "QUEUE LENGTH: ${QUEUE_LEN}"
+}
+
+log_can () {
+    candump -adex can0
+}
+
+send_can='
+    i=1
+    while [ "$i" -ne 26 ]
+    do
+        cansend can1 002#R0
+        i=$((i + 1))
+    done
+'
+
+spawn_tmux_session () {
+    tmux new-session -d -s cantest
+    tmux split-window -h
+    tmux send-keys -t cantest:0.0 'candump -adex can0' C-m
+    tmux send-keys -t cantest:0.1 "${send_can}" C-m
+    tmux attach-session -t cantest 
+}
+
+main () {
+    print_info
+    sleep 2
+    sleep 4 && tmux kill-session -t cantest&
+    spawn_tmux_session
+}
+
+main


### PR DESCRIPTION
Updates the version of the BCM code that is installed by the setup.sh script. The 1.75 version contains multiple SPI bug fixes.

Addition of the test_can.sh script helps as a sanity check that CAN hardware is functional, as well as demos maximum speed.

closes #22 #24 